### PR TITLE
#14 upgrading default version to prom2teams 2.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
 Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
- including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md
+ including treating everyone with respect: https://github.com/idealista/prom2teams-role/blob/master/CODE_OF_CONDUCT.md
 
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prom2teams-role/tree/develop)
+### Changed
+- *Update prom2teams version to 2.3.0* @dortegau
 
 ## [2.0.1](https://github.com/idealista/prom2teams-role/tree/2.0.1)
 [Full Changelog](https://github.com/idealista/prom2teams-role/compare/2.0.0...2.0.1)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-prom2teams_version: 2.2.2
+prom2teams_version: 2.3.0
 prom2teams_required_libs:
   - python3
   - python3-pip


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Upgrading default version to prom2teams 2.3.0