### PR TITLE
Prom2teams v2.4.0 and ability to configure Prometheus metrics endpoint

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-prom2teams_version: 2.3.1
+prom2teams_version: 2.4.0
 prom2teams_required_libs:
   - python3
   - python3-pip
@@ -38,6 +38,7 @@ prom2teams_socket: file # file | http
 prom2teams_host: 0.0.0.0
 prom2teams_port: 8089
 prom2teams_name: "{{ ansible_hostname }}"
+prom2teams_prometheus_metrics: False # True, False
 #prom2teams_template_path: # Define if needed
 #prom2teams_groupalertsby: # Define if used
 

--- a/templates/prom2teams.j2
+++ b/templates/prom2teams.j2
@@ -2,3 +2,6 @@
 # Prom2Teams Environment
 APP_ENVIRONMENT={{ prom2teams_environment }}
 APP_CONFIG_FILE={{ prom2teams_config_file }}
+{% if prom2teams_prometheus_metrics %}
+PROM2TEAMS_PROMETHEUS_METRICS=true
+{% endif %}


### PR DESCRIPTION
- Upgrade prom2teams to v2.4.0
- Add `prom2teams_prometheus_metrics` to use the metrics endpoint